### PR TITLE
adding THE depot

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
     * [learnings labs](https://learninglabs.cisco.com/labs/tags/spark) - tutorials (by Cisco DevNet)
     * [security whitepaper](http://www.cisco.com/c/dam/en/us/solutions/collateral/collaboration/cloud-collaboration/cisco-spark-security-white-paper.pdf) - details the end-to-end secured service (by Cisco Spark)
 * Support
-    * [developer support](https://developer.ciscospark.com/support.html) - 24/7 free support service (by Spark for Developers)
+    * [depot](https://depot.ciscospark.com/) - hub for integrations & bots (by Cisco)
+    * [devsupport](https://developer.ciscospark.com/support.html) - 24/7 developer support community (by Spark for Developers)
     * [status page](https://status.ciscospark.com/) - service availability page for the Developer API (by Spark for Developers)
-
+    
 
 ## Samples
 


### PR DESCRIPTION
depot could fit in both an Integration section (frameworks, cloud services, depot) or in the Reference.

for now, I suggest we leave the Integration section dedicated to Integration Frameworks.
- [x] I have added my resource in alphabetical order
- [x] I know that this resource was not listed before
- [ ] I have added a link to the source code repo (except for documentation, articles etc.)
- [x] I have checked my resource is properly documented
- [x] I have added a synthetic description of my resource
- [x] I have read the [Contribution guidelines](https://github.com/CiscoDevNet/awesome-ciscospark/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/CiscoDevNet/awesome-ciscospark/blob/master/CONTRIBUTING.md#quality-standard).
