### PR TITLE
Added accounts-ciscospark meteor package

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,5 +170,5 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 * [sparkcli](https://github.com/tdeckers/sparkcli) - A command line interface (by tdeckers).
 * [spark-messages](https://github.com/brh55/spark-messages) - A collection of helpers to ensure consistent formatting of markdown messages (by brh55).
 * [Spark-Space-Archive](https://github.com/DJF3/Spark-Space-Archive) - Archive messages to a single HTML file (by DJF3).
-* [swagger-cisco-spark](https://github.com/cumberlandgroup/swagger-cisco-spark) - Swagger definition file for Cisco Spark API v1 (by nmarus). Updated for OpenAPI (by levensailor)
+* [swagger-cisco-spark](https://github.com/cumberlandgroup/swagger-cisco-spark) - Swagger definition file for Cisco Spark API v1 (by nmarus).
 * [whproxy](https://github.com/sgrimee/whproxy) - Proxy incoming webhooks to established websockets (by sgrimee).

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 * Swift
      * [Kitchen Sink](https://github.com/ciscospark/spark-ios-sdk-example) - Developer friendly sample to showcase Spark iOS SDK features (by Spark for Developers).
      * [Spark iOS SDK Wrapper](https://github.com/jfield44/SparkSDKWrapper) - Wrapper library offering a drop in voice and video calling component (by jfield44).
-     * [accounts-ciscospark](https://github.com/levensailor/accounts-ciscospark) - Meteor.js Oauth accounts package
 
 ## Integration services
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 * Swift
      * [Kitchen Sink](https://github.com/ciscospark/spark-ios-sdk-example) - Developer friendly sample to showcase Spark iOS SDK features (by Spark for Developers).
      * [Spark iOS SDK Wrapper](https://github.com/jfield44/SparkSDKWrapper) - Wrapper library offering a drop in voice and video calling component (by jfield44).
-
+     * [accounts-ciscospark](https://github.com/levensailor/accounts-ciscospark) - Meteor.js Oauth accounts package
 
 ## Integration services
 
@@ -124,6 +124,7 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
      * [Zapier](https://zapier.com/zapbook/cisco-spark/) - Recommended Spark zaps.
 * Wiring Engines
      * [node-red](https://github.com/cumberlandgroup/node-red-contrib-spark) - Node-RED Node.js to integrate with the Cisco Spark API (by nmarus).
+
 
 
 ## Reference
@@ -170,5 +171,5 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 * [sparkcli](https://github.com/tdeckers/sparkcli) - A command line interface (by tdeckers).
 * [spark-messages](https://github.com/brh55/spark-messages) - A collection of helpers to ensure consistent formatting of markdown messages (by brh55).
 * [Spark-Space-Archive](https://github.com/DJF3/Spark-Space-Archive) - Archive messages to a single HTML file (by DJF3).
-* [swagger-cisco-spark](https://github.com/cumberlandgroup/swagger-cisco-spark) - Swagger definition file for Cisco Spark API v1 (by nmarus).
+* [swagger-cisco-spark](https://github.com/cumberlandgroup/swagger-cisco-spark) - Swagger definition file for Cisco Spark API v1 (by nmarus). Updated for OpenAPI (by levensailor)
 * [whproxy](https://github.com/sgrimee/whproxy) - Proxy incoming webhooks to established websockets (by sgrimee).

--- a/README.md
+++ b/README.md
@@ -170,5 +170,5 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 * [sparkcli](https://github.com/tdeckers/sparkcli) - A command line interface (by tdeckers).
 * [spark-messages](https://github.com/brh55/spark-messages) - A collection of helpers to ensure consistent formatting of markdown messages (by brh55).
 * [Spark-Space-Archive](https://github.com/DJF3/Spark-Space-Archive) - Archive messages to a single HTML file (by DJF3).
-* [swagger-cisco-spark](https://github.com/cumberlandgroup/swagger-cisco-spark) - Swagger definition file for Cisco Spark API v1 (by nmarus). Updated definition file from Swagger to OpenAPI 3.0 (by levensailor)
+* [swagger-cisco-spark](https://github.com/cumberlandgroup/swagger-cisco-spark) - Swagger definition file for Cisco Spark API v1 (by nmarus). Updated definition file from Swagger to OpenAPI 3.0 specifications (by levensailor)
 * [whproxy](https://github.com/sgrimee/whproxy) - Proxy incoming webhooks to established websockets (by sgrimee).

--- a/README.md
+++ b/README.md
@@ -170,5 +170,5 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 * [sparkcli](https://github.com/tdeckers/sparkcli) - A command line interface (by tdeckers).
 * [spark-messages](https://github.com/brh55/spark-messages) - A collection of helpers to ensure consistent formatting of markdown messages (by brh55).
 * [Spark-Space-Archive](https://github.com/DJF3/Spark-Space-Archive) - Archive messages to a single HTML file (by DJF3).
-* [swagger-cisco-spark](https://github.com/cumberlandgroup/swagger-cisco-spark) - Swagger definition file for Cisco Spark API v1 (by nmarus).
+* [swagger-cisco-spark](https://github.com/cumberlandgroup/swagger-cisco-spark) - Swagger definition file for Cisco Spark API v1 (by nmarus). Updated definition file from Swagger to OpenAPI 3.0 (by levensailor)
 * [whproxy](https://github.com/sgrimee/whproxy) - Proxy incoming webhooks to established websockets (by sgrimee).

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
      * [Kitchen Sink](https://github.com/ciscospark/spark-ios-sdk-example) - Developer friendly sample to showcase Spark iOS SDK features (by Spark for Developers).
      * [Spark iOS SDK Wrapper](https://github.com/jfield44/SparkSDKWrapper) - Wrapper library offering a drop in voice and video calling component (by jfield44).
 
+
 ## Integration services
 
 *Cloud platforms and wiring engines to build Cisco Spark Apps with little to no coding*

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
      * [node-red](https://github.com/cumberlandgroup/node-red-contrib-spark) - Node-RED Node.js to integrate with the Cisco Spark API (by nmarus).
 
 
-
 ## Reference
 
 *Resources maintained by Cisco Product teams and Developer Communities*


### PR DESCRIPTION
For meteor users, you can just type "meteor add levensailor:accounts-ciscospark" and it will add button to your login page which allows you to configure, and then subsequently login to your application. The package will add a profile to your mongo collection for each user with the output of get/user from the api, once authenticated.