### PR TITLE
Update node sample references

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,21 @@ If you see a package or project here that is no longer maintained or is not a go
 DISCLAIMER: Cisco does not make any commitments about the resources listed in this document, nor the accuracy of the third party resources and any content accessible via the links below.
 
 
-- [Bot frameworks](#bot-frameworks)
-- [Clients SDKs](#client-sdks)
-   - [REST API](#rest-api-clients)
-   - [Advanced APIs](#advanced-apis)
-- [Code samples](#code-samples)
-   - [REST API samples](#rest-api-samples)
-   - [Bot samples](#bot-samples)
-   - [Mobile samples](#mobile-samples)
-   - [Web SDK & Widgets samples](#web-sdk--widgets-samples)
-- [Integration Services](#integration-services)
-- [Reference](#reference)
-- [Tools](#tools)
+- [Awesome Webex ![Awesome](https://github.com/sindresorhus/awesome) [![published](https://static.production.devnetcloud.com/codeexchange/assets/images/devnet-published.svg)](https://developer.cisco.com/codeexchange/github/repo/CiscoDevNet/awesome-webex)](#awesome-webex-img-src%22httpsgithubcomsindresorhusawesome%22-alt%22awesome%22-img-src%22httpsstaticproductiondevnetcloudcomcodeexchangeassetsimagesdevnet-publishedsvg%22-alt%22published%22)
+    - [Contributing](#contributing)
+    - [Contents](#contents)
+  - [Bot frameworks](#bot-frameworks)
+  - [Client SDKs](#client-sdks)
+    - [REST API clients](#rest-api-clients)
+    - [Advanced APIs](#advanced-apis)
+  - [Code samples](#code-samples)
+    - [REST API samples](#rest-api-samples)
+    - [Bot samples](#bot-samples)
+    - [Mobile samples](#mobile-samples)
+    - [Web SDK & Widgets samples](#web-sdk--widgets-samples)
+  - [Integration services](#integration-services)
+  - [Reference](#reference)
+  - [Tools](#tools)
 
 
 ## Bot frameworks
@@ -43,7 +46,7 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 * Javascript
     * [Botkit](https://github.com/howdyai/botkit/tree/master/packages/botbuilder-adapter-webex) - Build conversational bots that can live on multiple platforms (by Howdy.ai).
     * [bot-connector](https://github.com/RecastAI/bot-connector/wiki/Channel-Cisco) - Connect your bot to multiple messaging channels (by Recast.ai).
-    * [flint](https://github.com/flint-bot/flint) - Bot SDK for Node.js (by nmarus).
+    * [webex-node-bot-framework](https://github.com/webex/webex-bot-node-framework) - Node framework based on webex-js-sdk (by webex)
     * [hubot-spark](https://github.com/tonybaloney/hubot-spark) - A Hubot integration (by tonybaloney).
     * [hubot-sparkwebhook](https://github.com/marchfederico/hubot-sparkwebhook) - A Hubot adapter (by marchfederico).
     * [node-sparkbot](https://github.com/CiscoDevNet/node-sparkbot) - Build bots in Node.js and experiment webhooks (by ObjectIsAdvantag).
@@ -71,7 +74,7 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 * Java
     * [spark-java-sdk](https://github.com/webex/spark-java-sdk) - A Java library for consuming the RESTful APIs (by Cisco Webex).
 * Node.js
-    * [ciscospark](https://github.com/webex/spark-js-sdk#nodejs) - A collection of Node.js modules targeting our REST API (by Cisco Webex).
+    * [Webex javascript SDK](https://webex.github.io/webex-js-sdk) - Javascript wrapper for Webex REST API (by Cisco Webex).
     * [sparkclient](https://github.com/marchfederico/node-sparkclient) - A simple Node.js module (by marchfederico).
     * [sparky](https://github.com/flint-bot/sparky) - A simple API wrapper for Node.js (by nmarus).
 * Perl
@@ -118,7 +121,7 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
     * [email2spark](https://github.com/marchfederico/email2spark/blob/master/email2spark.js) - Move an email thread to a space using Mailgun (by marchfederico).
     * [generator-spark-bot](https://github.com/brh55/generator-spark-bot) - A yeoman generator that scaffolds out a bot with usability and simplicity in mind (by brh55).
     * [sparkbot-samples](https://github.com/CiscoDevNet/node-sparkbot-samples) - Examples of bots, leveraging the node-sparkbot framework (by ObjectIsAdvantag).
-    * [sparkbotstarter](https://github.com/valgaze/sparkbotstarter) - Starter kit for a simple bot leveraging flint (by valgaze).
+    * [webex-bot-starter](https://github.com/WebexSamples/webex-bot-starter) - Starter kit for a simple bot leveraging the webex-node-bot-framework (by WebexSamples).
     * [zbot](https://github.com/akalsey/zbot) - Play the Zork interactive game in spaces (by akalsey).
 * Node.js (Botkit)
     * [botkit samples](https://github.com/CiscoDevNet/botkit-ciscospark-samples) - Conversational bot samples built with Botkit (by ObjectIsAdvantag).


### PR DESCRIPTION
Update references to ciscospark, flint and sparkybot to webex-js-sdk, webex-node-bot-framework, and webex-bot-starter respectively.