### PR TITLE
Replace flint framework with webex-node-bot-framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,21 @@ If you see a package or project here that is no longer maintained or is not a go
 DISCLAIMER: Cisco does not make any commitments about the resources listed in this document, nor the accuracy of the third party resources and any content accessible via the links below.
 
 
-- [Bot frameworks](#bot-frameworks)
-- [Clients SDKs](#client-sdks)
-   - [REST API](#rest-api-clients)
-   - [Advanced APIs](#advanced-apis)
-- [Code samples](#code-samples)
-   - [REST API samples](#rest-api-samples)
-   - [Bot samples](#bot-samples)
-   - [Mobile samples](#mobile-samples)
-   - [Web SDK & Widgets samples](#web-sdk--widgets-samples)
-- [Integration Services](#integration-services)
-- [Reference](#reference)
-- [Tools](#tools)
+- [Awesome Webex ![Awesome](https://github.com/sindresorhus/awesome) [![published](https://static.production.devnetcloud.com/codeexchange/assets/images/devnet-published.svg)](https://developer.cisco.com/codeexchange/github/repo/CiscoDevNet/awesome-webex)](#awesome-webex-img-src%22httpsgithubcomsindresorhusawesome%22-alt%22awesome%22-img-src%22httpsstaticproductiondevnetcloudcomcodeexchangeassetsimagesdevnet-publishedsvg%22-alt%22published%22)
+    - [Contributing](#contributing)
+    - [Contents](#contents)
+  - [Bot frameworks](#bot-frameworks)
+  - [Client SDKs](#client-sdks)
+    - [REST API clients](#rest-api-clients)
+    - [Advanced APIs](#advanced-apis)
+  - [Code samples](#code-samples)
+    - [REST API samples](#rest-api-samples)
+    - [Bot samples](#bot-samples)
+    - [Mobile samples](#mobile-samples)
+    - [Web SDK & Widgets samples](#web-sdk--widgets-samples)
+  - [Integration services](#integration-services)
+  - [Reference](#reference)
+  - [Tools](#tools)
 
 
 ## Bot frameworks
@@ -41,9 +44,9 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 * Java
     * [odl-sparkbot](https://github.com/CiscoDevNet/odl-sparkbot) - An SDK for developing clients and bots on top of the OpenDaylight platform (by jmedved).
 * Javascript
+    * [webex-node-bot-framework](https://github.com/webex/webex-bot-node-framework) - Bot framework for node.js based on webex-js-sdk (by webex)
     * [Botkit](https://github.com/howdyai/botkit/tree/master/packages/botbuilder-adapter-webex) - Build conversational bots that can live on multiple platforms (by Howdy.ai).
     * [bot-connector](https://github.com/RecastAI/bot-connector/wiki/Channel-Cisco) - Connect your bot to multiple messaging channels (by Recast.ai).
-    * [flint](https://github.com/flint-bot/flint) - Bot SDK for Node.js (by nmarus).
     * [hubot-spark](https://github.com/tonybaloney/hubot-spark) - A Hubot integration (by tonybaloney).
     * [hubot-sparkwebhook](https://github.com/marchfederico/hubot-sparkwebhook) - A Hubot adapter (by marchfederico).
     * [node-sparkbot](https://github.com/CiscoDevNet/node-sparkbot) - Build bots in Node.js and experiment webhooks (by ObjectIsAdvantag).


### PR DESCRIPTION
Remove no longer maintained flint framework.  Replace with new webex-node-bot-framework (based on flint)