### PR TITLE
Rename js sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 * Java
     * [spark-java-sdk](https://github.com/webex/spark-java-sdk) - A Java library for consuming the RESTful APIs (by Cisco Webex).
 * Node.js
-    * [ciscospark](https://github.com/webex/spark-js-sdk#nodejs) - A collection of Node.js modules targeting our REST API (by Cisco Webex).
+    * [Webex javascript SDK](https://webex.github.io/webex-js-sdk) - Javascript wrapper for Webex REST APIs which also includes additional browser extensions for embedding Webex messaging and meeting capabiltities into 3rd party web applications (by Cisco Webex).
     * [sparkclient](https://github.com/marchfederico/node-sparkclient) - A simple Node.js module (by marchfederico).
     * [sparky](https://github.com/flint-bot/sparky) - A simple API wrapper for Node.js (by nmarus).
 * Perl

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ DISCLAIMER: Cisco does not make any commitments about the resources listed in th
 ### REST API samples
 
 * Node.js
-    * [integration-sample](https://github.com/CiscoDevNet/webex-integration-sample) - Creating a server-side OAuth integration (by ObjectIsAdvantag).
+    * [integration-sample](https://github.com/CiscoDevNet/spark-integration-sample) - Creating a server-side OAuth integration (by ObjectIsAdvantag).
     * [node-sparky-samples](https://github.com/CiscoDevNet/node-sparky-samples) - Client samples with node-sparky (by ObjectIsAdvantag).
     * [spark-messages](https://github.com/brh55/spark-messages) - A collection of helpers to ensure consistent formatting of markdown messages (by brh55).
 * Python


### PR DESCRIPTION
Remove reference to deprecated ciscospark-js-sdk.  Replace with webex-js-sdk